### PR TITLE
add api v1 sunsetting warning

### DIFF
--- a/src/api-v1.md
+++ b/src/api-v1.md
@@ -1,7 +1,7 @@
 # API v1
 
-::: info
-This version of the API is stable. Future features will be added to [version 2](/api-v2).
+::: Warning
+This version of the API will be sunsetted soon. Please use [version 2](/api-v2) instead.
 :::
 
 TaskRatchet has an API you can use to list, update, and create new tasks, among other things.

--- a/src/api-v1.md
+++ b/src/api-v1.md
@@ -1,7 +1,7 @@
 # API v1
 
-::: Warning
-This version of the API will be sunsetted soon. Please use [version 2](/api-v2) instead.
+::: warning
+This version of the API will be sunsetted on 2025-09-12. Please use [version 2](/api-v2) instead.
 :::
 
 TaskRatchet has an API you can use to list, update, and create new tasks, among other things.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changed the API v1 top banner from informational to a warning, stating v1 will be sunset on 2025-09-12 and directing users to v2.
  * Clarifies deprecation timeline and migration path to reduce confusion about v1 stability and future development.
  * No functional changes to APIs or SDKs; document content outside the banner remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->